### PR TITLE
Added support for vercel/pkg.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,23 @@ const { spawn } = require('child_process');
 const ews = require('express-ws');
 const ps = require('ps-node');
 const { version } = require('./package.json');
+const fs = require('fs');
+const path = require('path');
+
+const copy = async (source, target) => {
+    fs.mkdirSync(process.cwd() + '\\temp');
+    await (fs.createReadStream(source).pipe(fs.createWriteStream(target)));
+}
+
+let target;
+//@ts-ignore
+if (process.pkg) {
+  target = path.join(process.cwd() + '\\temp' + '\\ffmpeg.exe');
+copy(ffmpegPath, target).then(d => {
+  fs.chmodSync(target, 0o765);
+}
+).catch(e => console.log(e.message));
+}
 
 /**
  * @typedef {{
@@ -39,7 +56,8 @@ class InboundStreamWrapper {
     }
 
     this.stream = spawn(
-      ffmpegPath,
+      //@ts-ignore
+      process.pkg ? target : ffmpegPath,,
       [
         ...(transport ? ['-rtsp_transport', transport] : []), // this must come before `-i [url]`, see #82
         '-i',


### PR DESCRIPTION
Simple edit to allow vercel/pkg to work with ffmpeg executable. If the program detects it's a pkg it will create temp folder with ffmpeg.exe. This executable will be copied from the snapshot of the package.